### PR TITLE
Add a filter to the wysiwyg args

### DIFF
--- a/templates/field-wysiwyg.tpl.html
+++ b/templates/field-wysiwyg.tpl.html
@@ -2,7 +2,7 @@
 
 ob_start();
 
-$args = array(
+$args = apply_filters( 'mpb_wysiwyg_args', array(
 	'textarea_name' => 'mpb-placeholder-name',
 	'textarea_rows' => 3,
 	'teeny' => true,
@@ -10,7 +10,7 @@ $args = array(
 		'resize' => false,
 		'wp_autoresize_on' => true,
 	)
-);
+) );
 
 wp_editor( 'mpb-placeholder-content', 'mpb-placeholder-id', $args );
 


### PR DESCRIPTION
@sanchothefat originally added here:  https://github.com/joehoyle/modular-page-builder/pull/1

Usage Example:

```
// Enable full editor menu bar (includes font styles)
add_filter( 'mpb_wysiwyg_args', function ( $args ) {
    $args['teeny'] = false;
    return $args;
} );
```
