### PR TITLE
Add Links to the module responses

### DIFF
--- a/inc/class-builder-post-meta.php
+++ b/inc/class-builder-post-meta.php
@@ -24,7 +24,7 @@ class Builder_Post_Meta extends Builder {
 			return $response;
 		}, 11, 2 );
 
-		add_filter( "wp_get_revision_ui_diff", array( $this, 'revision_ui_diff' ), 10, 3 );
+		add_filter( 'wp_get_revision_ui_diff', array( $this, 'revision_ui_diff' ), 10, 3 );
 
 		add_filter( '_wp_post_revision_fields', function( $fields ) {
 			$fields['modular-page-builder-data'] = __( 'Modular Page Builder Data' );
@@ -132,7 +132,7 @@ class Builder_Post_Meta extends Builder {
 				json_encode( $from_data ),
 				json_encode( $to_data ),
 				array( 'show_split_view' => true )
-			)
+			),
 		);
 
 		return $return;
@@ -153,7 +153,7 @@ class Builder_Post_Meta extends Builder {
 					'type'        => 'array',
 					'description' => 'Data for all the modules',
 				),
-			)
+			),
 		);
 
 		register_api_field(
@@ -246,5 +246,4 @@ class Builder_Post_Meta extends Builder {
 			return post_type_supports( $post_type, $this->id );
 		} );
 	}
-
 }

--- a/inc/modules/class-image.php
+++ b/inc/modules/class-image.php
@@ -50,4 +50,19 @@ class Image extends Module {
 		}, $data['image'] );
 		return $data;
 	}
+
+	public function get_rest_links() {
+		$data = parent::get_json();
+
+		if ( ! $data['image'] ) {
+			return array();
+		}
+
+		return array(
+			'image' => array(
+				'embeddable' => true,
+				'href'       => rest_url( sprintf( '/wp/v2/media/%d', $data['image'][0] ) ),
+			),
+		);
+	}
 }

--- a/modular-page-builder.php
+++ b/modular-page-builder.php
@@ -56,5 +56,3 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require __DIR__ . '/inc/class-wp-cli.php';
 	WP_CLI::add_command( 'modular-page-builder', __NAMESPACE__ . '\\CLI' );
 }
-
-


### PR DESCRIPTION
When a module instance sends it's data JSON, it's handy to be able to provide resource links
like the rest api nativly supports so the client can get access to the via lookup, or passing `?_embed`.

This allows for another `get_rest_links` method on a module class to export any links ot other resources for that 
instance of the module.
