### PR TITLE
Bugs - Better logic for fetching post ID and broken search

### DIFF
--- a/inc/class-builder-post-meta.php
+++ b/inc/class-builder-post-meta.php
@@ -248,8 +248,15 @@ class Builder_Post_Meta extends Builder {
 		}
 
 		$allowed_for_screen = false;
+		$id                 = null;
 
-		if ( $id = get_the_ID() ) {
+		if ( isset( $_GET['post'] ) ) {
+			$id = absint( $_GET['post'] );
+		} elseif ( isset( $_POST['post_ID'] ) ) {
+			$id = absint( $_POST['post_ID'] );
+		}
+
+		if ( $id ) {
 			$allowed_for_screen = $this->is_enabled_for_post( $id );
 		}
 

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -61,8 +61,8 @@ class Plugin {
 			}
 		}
 
-		if ( isset( $_GET['q'] ) ) {
-			$query['s'] = sanitize_text_field( $_GET['q'] );
+		if ( isset( $_GET['s'] ) ) {
+			$query['s'] = sanitize_text_field( $_GET['s'] );
 		}
 
 		if ( isset( $_GET['page'] ) ) {

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -51,6 +51,7 @@ class Plugin {
 			'posts_per_page' => 5,
 			'perm'           => 'readable',
 			'paged'          => 1,
+			'post_status'    => 'publish',
 		);
 
 		if ( isset( $_GET['post_type'] ) ) {
@@ -72,6 +73,10 @@ class Plugin {
 		if ( isset( $_GET['post__in'] ) ) {
 			$query['post__in'] = explode( ',', sanitize_text_field( $_GET['post__in'] ) );
 			$query['post__in'] = array_map( 'absint', $query['post__in'] );
+		}
+
+		if ( isset( $_GET['post_status'] ) ) {
+			$query['post_status'] = sanitize_text_field( $_GET['post_status'] );
 		}
 
 		$query = new WP_Query( $query );


### PR DESCRIPTION
We can't rely on get_the_ID here. If the template messes with global `$post`, this won't be correct and saving can fail. Its better to grab the post ID from GET/POST